### PR TITLE
[BUGFIX] Update bootstrap.php

### DIFF
--- a/app/code/community/EcomDev/PHPUnit/bootstrap.php
+++ b/app/code/community/EcomDev/PHPUnit/bootstrap.php
@@ -51,6 +51,11 @@ if (!defined('ECOMDEV_PHPUNIT_NO_AUTOLOADER')) {
             )
         );
 
-        @include $filePath . '.php';
+        $classFile = $filePath . '.php';
+        if (stream_resolve_include_path($classFile)) {
+            return include $classFile;
+        } else {
+            return false;
+        }
     });
 }


### PR DESCRIPTION
Autoloader implementations MUST NOT throw exceptions, MUST NOT raise errors of any level.

Fixes errors like this:
PHP Fatal error:  Uncaught exception 'Exception' with message 'Warning: include(PHPUnit/Extensions/Story/TestCase.php): failed to open stream: No such file or directory  in [..]/vendor/ecomdev/phpunit/app/code/community/EcomDev/PHPUnit/bootstrap.php on line 54' in [...]/htdocs/app/code/core/Mage/Core/functions.php:245
